### PR TITLE
Fuerza que resultados de 'animate' sean gif

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,7 +2,6 @@
   "hubot-diagnostics",
   "hubot-help",
   "hubot-heroku-keepalive",
-  "hubot-google-images",
   "hubot-pugme",
   "hubot-maps",
   "hubot-redis-brain",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "hubot-caniuse": "^1.0.3",
     "hubot-cpf": "^1.0.4",
     "hubot-diagnostics": "0.0.1",
-    "hubot-google-images": "^0.1.4",
     "hubot-help": "^0.1.1",
     "hubot-heroku-keepalive": "0.0.4",
     "hubot-insulter": "^1.0.2",

--- a/scripts/google-images.coffee
+++ b/scripts/google-images.coffee
@@ -1,0 +1,51 @@
+# Description:
+#   A way to interact with the Google Images API.
+#
+# Commands:
+#   hubot image me <query> - The Original. Queries Google Images for <query> and returns a random top result.
+#   hubot animate me <query> - The same thing as `image me`, except adds a few parameters to try to return an animated GIF instead.
+#   hubot mustache me <url> - Adds a mustache to the specified URL.
+#   hubot mustache me <query> - Searches Google Images for the specified query and mustaches it.
+
+module.exports = (robot) ->
+  robot.respond /(image|img)( me)? (.*)/i, (msg) ->
+    imageMe msg, msg.match[3], (url) ->
+      msg.send url
+
+  robot.respond /animate( me)? (.*)/i, (msg) ->
+    imageMe msg, msg.match[2], true, (url) ->
+      msg.send url
+
+  robot.respond /(?:mo?u)?sta(?:s|c)h(?:e|ify)?(?: me)? (.*)/i, (msg) ->
+    mustachify = "http://mustachify.me/rand?src="
+    imagery = msg.match[1]
+
+    if imagery.match /^https?:\/\//i
+      encodedUrl = encodeURIComponent imagery
+      msg.send "#{mustachify}#{encodedUrl}"
+    else
+      imageMe msg, imagery, false, true, (url) ->
+        encodedUrl = encodeURIComponent url
+        msg.send "#{mustachify}#{encodedUrl}"
+
+imageMe = (msg, query, animated, faces, cb) ->
+  cb = animated if typeof animated == 'function'
+  cb = faces if typeof faces == 'function'
+  q = v: '1.0', rsz: '8', q: query, safe: 'active'
+  q.imgtype = 'animated' if typeof animated is 'boolean' and animated is true
+  q.imgtype = 'face' if typeof faces is 'boolean' and faces is true
+  msg.http('http://ajax.googleapis.com/ajax/services/search/images')
+    .query(q)
+    .get() (err, res, body) ->
+      images = JSON.parse(body)
+      images = images.responseData?.results
+      if images?.length > 0
+        image = msg.random images
+        cb ensureImageExtension image.unescapedUrl
+
+ensureImageExtension = (url) ->
+  ext = url.split('.').pop()
+  if /(png|jpe?g|gif)/i.test(ext)
+    url
+  else
+    "#{url}#.png"

--- a/scripts/google-images.coffee
+++ b/scripts/google-images.coffee
@@ -32,6 +32,7 @@ imageMe = (msg, query, animated, faces, cb) ->
   cb = animated if typeof animated == 'function'
   cb = faces if typeof faces == 'function'
   q = v: '1.0', rsz: '8', q: query, safe: 'active'
+  q.as_filetype = 'gif' if typeof animated is 'boolean' and animated is true
   q.imgtype = 'animated' if typeof animated is 'boolean' and animated is true
   q.imgtype = 'face' if typeof faces is 'boolean' and faces is true
   msg.http('http://ajax.googleapis.com/ajax/services/search/images')


### PR DESCRIPTION
Es un parche mientras actualizan a la versión nueva del script de google images (que usa la API y por lo tanto está limitada a 100 queries diarias)